### PR TITLE
Suggestion for rel="credits"

### DIFF
--- a/link-relations.xml
+++ b/link-relations.xml
@@ -109,11 +109,18 @@ using the <xref type="uri" data="https://github.com/link-relations/registry">reg
     link's context.</description>
     <spec><xref type="uri" data="http://www.w3.org/TR/1999/REC-html401-19991224"/></spec>
   </record>
-  
+
   <record>
     <value>create-form</value>
     <description>The target IRI points to a resource where a submission form can be obtained.</description>
     <spec><xref type="rfc" data="rfc6861"/></spec>
+  </record>
+
+  <record>
+    <value>credits</value>
+    <description>Denotes a resource that lists the names of the people who contributed to some part or other of a website or Web application, especially those who would not ordinarily be credited in the main text of the site.</description>
+    <spec><xref type="uri" data="https://creditstxt.com/"/></spec>
+    <note>Examples: authors of open-source frameworks and components, website themes and stylesheets, visual design, typography, etc.</note>
   </record>
   
   <record>

--- a/link-relations.xml
+++ b/link-relations.xml
@@ -118,7 +118,7 @@ using the <xref type="uri" data="https://github.com/link-relations/registry">reg
 
   <record>
     <value>credits</value>
-    <description>Denotes a resource that lists the names of the people who contributed to some part or other of a resource or collection of resources, including but not limited to a website or Web application. An explicit credits link supplements any ad-hoc credits in the main body of the referring resource, affording a space for those who would not ordinarily be credited therein.</description>
+    <description>Denotes a resource that lists the names of the people who contributed to some part or other of a resource or collection of resources, such as a website or Web application. An explicit credits link supplements any ad-hoc credits in the main body of the referring resource, affording a space for those who would not ordinarily be credited in the main body.</description>
     <spec><xref type="uri" data="https://creditstxt.com/"/></spec>
     <note>Examples: authors of open-source frameworks and components, website themes and stylesheets, visual design, typography, etc.</note>
   </record>

--- a/link-relations.xml
+++ b/link-relations.xml
@@ -118,7 +118,7 @@ using the <xref type="uri" data="https://github.com/link-relations/registry">reg
 
   <record>
     <value>credits</value>
-    <description>Denotes a resource that lists the names of the people who contributed to some part or other of a website or Web application, especially those who would not ordinarily be credited in the main text of the site.</description>
+    <description>Denotes a resource that lists the names of the people who contributed to some part or other of a resource or collection of resources, including but not limited to a website or Web application. An explicit credits link supplements any ad-hoc credits in the main body of the referring resource, affording a space for those who would not ordinarily be credited therein.</description>
     <spec><xref type="uri" data="https://creditstxt.com/"/></spec>
     <note>Examples: authors of open-source frameworks and components, website themes and stylesheets, visual design, typography, etc.</note>
   </record>


### PR DESCRIPTION
On behalf of @kemitchell's [creditstxt.com](https://creditstxt.com/) I'm applying to register rel="credits". I am referencing the procedure in the `README` along with issue #4 and PR #5. I figure I'll save the database entry and forgo opening an issue and just submit the PR.

* **Relation name:** `credits`
* **Description:**  Denotes a resource that lists the names of the people who contributed to some part or other of a website or Web application, especially those who would not ordinarily be credited in the main text of the site.
* **Reference:** https://creditstxt.com/

Examples: authors of open-source frameworks and components, website themes and stylesheets, visual design, typography, etc.