### PR TITLE
Correct bug in intervalMetBy description

### DIFF
--- a/link-relations.xml
+++ b/link-relations.xml
@@ -316,7 +316,7 @@ using the <xref type="uri" data="https://github.com/link-relations/registry">reg
   
   <record>
     <value>intervalMetBy</value>
-    <description>refers to a resource associated with a time interval whose beginning coincides with the end of the time interval associated with the context resource</description>
+    <description>refers to a resource associated with a time interval whose end coincides with the beginning of the time interval associated with the context resource</description>
     <spec><xref type="uri" data="https://www.w3.org/TR/owl-time/#time:intervalMetBy"/> section 4.2.31</spec>
   </record>
   


### PR DESCRIPTION
In the course of preparing the [IANA Considerations section for OWL-Time,](https://rawgit.com/w3c/sdw/time-iana-considerations/time/#iana-links) I found that one of the registered descriptions had an error. This PR fixes the problem and aligns it with the W3C document. 